### PR TITLE
Closing#1 fix gcc@5 install command

### DIFF
--- a/homebrew/linuxbrew.sh
+++ b/homebrew/linuxbrew.sh
@@ -49,8 +49,9 @@ fi
 # Homebrew package installation {{{
 
 # To install gcc@5 we first need to fix the formula for linux.
-sed -i "19s/.*/    sha256 cellar: :any, x86_64_linux: \"cd94b6bc2189df7861c2c32c480f777984865dbab4107f493188feda5a05b80d\"/" $HOMEBREW/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gcc@5.rb
+# sed -i "19s/.*/    sha256 cellar: :any, x86_64_linux: \"cd94b6bc2189df7861c2c32c480f777984865dbab4107f493188feda5a05b80d\"/" $HOMEBREW/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gcc@5.rb
 brew install gcc@5 git
+brew install gcc@11 --force-bottle
 
 # Install zsh plugins
 brew install zsh-syntax-highlighting zsh-autosuggestions


### PR DESCRIPTION
SHA ref was already solved in linuxbrew-core. We do not need to patch it anymore.
Adding force-bottle to gcc@11 installation